### PR TITLE
feat: Add Remove, AddPrevious, AddNext methods and ToQueue conversion…

### DIFF
--- a/TAmeAtCoderLibrary/DoublyLinkedList.cs
+++ b/TAmeAtCoderLibrary/DoublyLinkedList.cs
@@ -79,6 +79,75 @@ public class DoublyLinkedList<T>
     }
 
     /// <summary>
+    /// 指定された値をリストから削除します。値が存在しない場合は何も行いません。
+    /// 値の前後の要素が存在する場合、それらの要素は自動的に連結されます。
+    /// </summary>
+    /// <param name="value">削除する値</param>
+    public void Remove(T value)
+    {
+        if (!_dic.ContainsKey(value))
+            return;
+
+        var reConnect = _dic[value].Previous != null && _dic[value].Next != null;
+        var before = _dic[value].Previous != null ? _dic[value].Previous.Value : default;
+        var after = _dic[value].Next != null ? _dic[value].Next.Value : default;
+
+        DisconnectPrevious(value);
+        DisconnectNext(value);
+
+        if (reConnect)
+            AddNext(before, after);
+
+        _dic.Remove(value);
+    }
+
+    /// <summary>
+    /// 指定された要素の前に新しい要素を追加します。
+    /// 既に前の要素が存在する場合、それらの関係を適切に再構築します。
+    /// </summary>
+    /// <param name="current">現在の要素</param>
+    /// <param name="pre">追加する前の要素</param>
+    public void AddPrevious(T current, T pre)
+    {
+        Add(current);
+        Add(pre);
+
+        var reConnect = _dic[current].Previous != null;
+        var prepre = _dic[current].Previous != null ? _dic[current].Previous.Value : default;
+
+        DisconnectPrevious(current);
+
+        _dic[current].Previous = _dic[pre];
+        _dic[current].Previous.Next = _dic[current];
+
+        if (reConnect)
+            AddPrevious(pre, prepre);
+    }
+
+    /// <summary>
+    /// 指定された要素の次に新しい要素を追加します。
+    /// 既に次の要素が存在する場合、それらの関係を適切に再構築します。
+    /// </summary>
+    /// <param name="current">現在の要素</param>
+    /// <param name="next">追加する次の要素</param>
+    public void AddNext(T current, T next)
+    {
+        Add(current);
+        Add(next);
+
+        var reConnect = _dic[current].Next != null;
+        var nextnext = _dic[current].Next != null ? _dic[current].Next.Value : default;
+
+        DisconnectNext(current);
+
+        _dic[current].Next = _dic[next];
+        _dic[current].Next.Previous = _dic[current];
+
+        if (reConnect)
+            AddNext(next, nextnext);
+    }
+
+    /// <summary>
     /// 指定された要素と前の要素との接続を切ります。
     /// </summary>
     /// <param name="current">対象の要素</param>
@@ -100,6 +169,30 @@ public class DoublyLinkedList<T>
 
         node.Next.Previous = null;
         node.Next = null;
+    }
+
+    /// <summary>
+    /// リンクリスト全体をキューに変換します。
+    /// リストの最初の要素から始まり、すべての要素を順序通りにキューに格納します。
+    /// </summary>
+    /// <returns>リンクリストの要素を順序通りに格納したキュー</returns>
+    public Queue<T> ToQueue()
+    {
+        var queue = new Queue<T>();
+
+        if (!_dic.TryGetValue(_dic.Keys.First(), out var node))
+            return queue;
+
+        while (node.Previous != null)
+            node = node.Previous;
+
+        do
+        {
+            queue.Enqueue(node.Value);
+            node = node.Next;
+        } while (node != null);
+
+        return queue;
     }
 
     /// <summary>

--- a/TAmeAtCoderLibrary/DoublyLinkedList.cs
+++ b/TAmeAtCoderLibrary/DoublyLinkedList.cs
@@ -6,7 +6,7 @@ namespace TAmeAtCoderLibrary;
 /// <typeparam name="T">リストに格納する要素の型</typeparam>
 public class DoublyLinkedList<T>
 {
-    private readonly Dictionary<T, Node> _dic = new();
+    private readonly Dictionary<T, Node> _nodeMap = new();
 
     /// <summary>
     /// 双方向連結リストの新しいインスタンスを初期化します。
@@ -18,20 +18,18 @@ public class DoublyLinkedList<T>
     /// 指定された値の前の要素を取得します。
     /// </summary>
     /// <param name="value">検索する値</param>
-    /// <param name="previous">前の要素が格納される出力パラメータ</param>
+    /// <param name="before">前の要素が格納される出力パラメータ</param>
     /// <returns>前の要素が存在する場合はtrue、存在しない場合はfalse</returns>
-    public bool TryGetPrevious(T value, out T previous)
+    public bool TryGetBefore(T value, out T before)
     {
-        if (_dic[value].Previous == null)
+        if (!_nodeMap.TryGetValue(value, out var node) || node.Before == null)
         {
-            previous = default;
+            before = default;
             return false;
         }
-        else
-        {
-            previous = _dic[value].Previous.Value;
-            return true;
-        }
+
+        before = node.Before.Value;
+        return true;
     }
 
     /// <summary>
@@ -42,16 +40,14 @@ public class DoublyLinkedList<T>
     /// <returns>次の要素が存在する場合はtrue、存在しない場合はfalse</returns>
     public bool TryGetNext(T value, out T next)
     {
-        if (_dic[value].Next == null)
+        if (!_nodeMap.TryGetValue(value, out var node) || node.Next == null)
         {
             next = default;
             return false;
         }
-        else
-        {
-            next = _dic[value].Next.Value;
-            return true;
-        }
+
+        next = node.Next.Value;
+        return true;
     }
 
     /// <summary>
@@ -60,22 +56,22 @@ public class DoublyLinkedList<T>
     /// <param name="value">追加する値</param>
     public void Add(T value)
     {
-        if (!_dic.ContainsKey(value))
-            _dic.Add(value, new Node(value));
+        if (!_nodeMap.ContainsKey(value))
+            _nodeMap.Add(value, new Node(value));
     }
 
     /// <summary>
     /// 2つの要素を連結させ、前後の関係を設定します。
     /// </summary>
-    /// <param name="previous">前の要素とする値</param>
+    /// <param name="before">前の要素とする値</param>
     /// <param name="next">次の要素とする値</param>
-    public void Connect(T previous, T next)
+    public void Link(T before, T next)
     {
-        Add(previous);
+        Add(before);
         Add(next);
 
-        _dic[previous].Next = _dic[next];
-        _dic[next].Previous = _dic[previous];
+        _nodeMap[before].Next = _nodeMap[next];
+        _nodeMap[next].Before = _nodeMap[before];
     }
 
     /// <summary>
@@ -85,20 +81,20 @@ public class DoublyLinkedList<T>
     /// <param name="value">削除する値</param>
     public void Remove(T value)
     {
-        if (!_dic.ContainsKey(value))
+        if (!_nodeMap.ContainsKey(value))
             return;
 
-        var reConnect = _dic[value].Previous != null && _dic[value].Next != null;
-        var before = _dic[value].Previous != null ? _dic[value].Previous.Value : default;
-        var after = _dic[value].Next != null ? _dic[value].Next.Value : default;
+        var reConnect = _nodeMap[value].Before != null && _nodeMap[value].Next != null;
+        var beforeVal = _nodeMap[value].Before != null ? _nodeMap[value].Before.Value : default;
+        var afterVal = _nodeMap[value].Next != null ? _nodeMap[value].Next.Value : default;
 
-        DisconnectPrevious(value);
-        DisconnectNext(value);
+        UnlinkBefore(value);
+        UnlinkNext(value);
 
         if (reConnect)
-            AddNext(before, after);
+            AddNext(beforeVal, afterVal);
 
-        _dic.Remove(value);
+        _nodeMap.Remove(value);
     }
 
     /// <summary>
@@ -106,22 +102,32 @@ public class DoublyLinkedList<T>
     /// 既に前の要素が存在する場合、それらの関係を適切に再構築します。
     /// </summary>
     /// <param name="current">現在の要素</param>
-    /// <param name="pre">追加する前の要素</param>
-    public void AddPrevious(T current, T pre)
+    /// <param name="before">追加する前の要素</param>
+    /// <param name="reConnect">既存の接続を維持するかどうか（デフォルトはtrue）</param>
+    public void AddBefore(T current, T before, bool reConnect = true)
     {
         Add(current);
-        Add(pre);
+        Add(before);
 
-        var reConnect = _dic[current].Previous != null;
-        var prepre = _dic[current].Previous != null ? _dic[current].Previous.Value : default;
+        var node = _nodeMap[current];
+        var beforeNode = _nodeMap[before];
 
-        DisconnectPrevious(current);
+        if (reConnect && node.Before != null)
+        {
+            var beforeBefore = node.Before.Value;
+            UnlinkBefore(current);
 
-        _dic[current].Previous = _dic[pre];
-        _dic[current].Previous.Next = _dic[current];
+            // 新しい要素の前に元の前の要素を連結
+            Link(beforeBefore, before);
+        }
+        else
+        {
+            UnlinkBefore(current);
+        }
 
-        if (reConnect)
-            AddPrevious(pre, prepre);
+        // 新しい要素を現在の要素の前に連結
+        beforeNode.Next = node;
+        node.Before = beforeNode;
     }
 
     /// <summary>
@@ -130,44 +136,54 @@ public class DoublyLinkedList<T>
     /// </summary>
     /// <param name="current">現在の要素</param>
     /// <param name="next">追加する次の要素</param>
-    public void AddNext(T current, T next)
+    /// <param name="reConnect">既存の接続を維持するかどうか（デフォルトはtrue）</param>
+    public void AddNext(T current, T next, bool reConnect = true)
     {
         Add(current);
         Add(next);
 
-        var reConnect = _dic[current].Next != null;
-        var nextnext = _dic[current].Next != null ? _dic[current].Next.Value : default;
+        var node = _nodeMap[current];
+        var nextNode = _nodeMap[next];
 
-        DisconnectNext(current);
+        if (reConnect && node.Next != null)
+        {
+            var afterNext = node.Next.Value;
+            UnlinkNext(current);
 
-        _dic[current].Next = _dic[next];
-        _dic[current].Next.Previous = _dic[current];
+            // 新しい要素の次に元の次の要素を連結
+            Link(next, afterNext);
+        }
+        else
+        {
+            UnlinkNext(current);
+        }
 
-        if (reConnect)
-            AddNext(next, nextnext);
+        // 新しい要素を現在の要素の次に連結
+        node.Next = nextNode;
+        nextNode.Before = node;
     }
 
     /// <summary>
     /// 指定された要素と前の要素との接続を切ります。
     /// </summary>
     /// <param name="current">対象の要素</param>
-    public void DisconnectPrevious(T current)
+    public void UnlinkBefore(T current)
     {
-        if (!_dic.TryGetValue(current, out var node) || node.Previous == null) return;
+        if (!_nodeMap.TryGetValue(current, out var node) || node.Before == null) return;
 
-        node.Previous.Next = null;
-        node.Previous = null;
+        node.Before.Next = null;
+        node.Before = null;
     }
 
     /// <summary>
     /// 指定された要素と次の要素との接続を切ります。
     /// </summary>
     /// <param name="current">対象の要素</param>
-    public void DisconnectNext(T current)
+    public void UnlinkNext(T current)
     {
-        if (!_dic.TryGetValue(current, out var node) || node.Next == null) return;
+        if (!_nodeMap.TryGetValue(current, out var node) || node.Next == null) return;
 
-        node.Next.Previous = null;
+        node.Next.Before = null;
         node.Next = null;
     }
 
@@ -180,17 +196,19 @@ public class DoublyLinkedList<T>
     {
         var queue = new Queue<T>();
 
-        if (!_dic.TryGetValue(_dic.Keys.First(), out var node))
+        if (_nodeMap.Count == 0)
             return queue;
 
-        while (node.Previous != null)
-            node = node.Previous;
+        var head = FindHeadNode();
+        if (head == null)
+            return queue;
 
+        var current = head;
         do
         {
-            queue.Enqueue(node.Value);
-            node = node.Next;
-        } while (node != null);
+            queue.Enqueue(current.Value);
+            current = current.Next;
+        } while (current != null);
 
         return queue;
     }
@@ -205,19 +223,42 @@ public class DoublyLinkedList<T>
     {
         var queue = new Queue<T>();
 
-        if (!_dic.TryGetValue(current, out var node))
+        if (!_nodeMap.TryGetValue(current, out var node))
             return queue;
 
-        while (node.Previous != null)
-            node = node.Previous;
+        // 先頭ノードを探す
+        var head = node;
+        while (head.Before != null)
+            head = head.Before;
 
+        // 先頭からキューに詰める
+        var currentNode = head;
         do
         {
-            queue.Enqueue(node.Value);
-            node = node.Next;
-        } while (node != null);
+            queue.Enqueue(currentNode.Value);
+            currentNode = currentNode.Next;
+        } while (currentNode != null);
 
         return queue;
+    }
+
+    /// <summary>
+    /// リンクリストの先頭ノードを検索します。
+    /// </summary>
+    /// <returns>先頭ノード。リストが空の場合はnull</returns>
+    private Node FindHeadNode()
+    {
+        if (_nodeMap.Count == 0)
+            return null;
+
+        var anyNode = _nodeMap.Values.First();
+        var head = anyNode;
+
+        // 先頭ノード（Beforeがnull）を見つける
+        while (head.Before != null)
+            head = head.Before;
+
+        return head;
     }
 
     /// <summary>
@@ -227,7 +268,7 @@ public class DoublyLinkedList<T>
     private class Node
     {
         internal T Value;
-        internal Node Previous;
+        internal Node Before; // Previousから名称変更
         internal Node Next;
 
         /// <summary>


### PR DESCRIPTION
このプルリクエストには、`TAmeAtCoderLibrary` 名前空間内の `DoublyLinkedList` クラスに対するいくつかの更新が含まれています。これらの変更は、変数名とメソッド名をより明確にするための変更、新機能の追加、およびクラス全体の構造の改善に焦点を当てています。

主な変更点は以下の通りです。

### 変数名とメソッド名の変更：
* `_dic` を `_nodeMap` に変更し、明確性を向上させました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL9-R9](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L9-R9))
* `TryGetPrevious` を `TryGetBefore` に変更し、関連するパラメータとロジックを更新しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL21-L35](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L21-L35))
* `DisconnectPrevious` を `UnlinkBefore` に変更し、関連するロジックを更新しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))
* `DisconnectNext` を `UnlinkNext` に変更し、関連するロジックを更新しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))

### 新機能：
* 指定された値をリストから削除し、必要に応じて隣接ノードを再接続する `Remove` メソッドを追加しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))
* 既存の接続を維持しながら、指定されたノードの前または後に要素を挿入する `AddBefore` および `AddNext` メソッドを追加しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))
* 連結リスト全体を先頭ノードから開始するキューに変換する `ToQueue` メソッドを追加しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))

### 構造的な改善：
* リストの先頭ノードを見つけるためのプライベートメソッド `FindHeadNode` を導入しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))
* 新しい命名規則との一貫性を保つため、`Node` クラスで `Previous` の代わりに `Before` を使用するように更新しました。 (`TAmeAtCoderLibrary/DoublyLinkedList.cs` [TAmeAtCoderLibrary/DoublyLinkedList.csL115-R271](diffhunk://#diff-0b6f1d61c5ffb474d8db1ceada22b56490843ffd20f473b94cc2880d7f6b4262L115-R271))

これらの変更により、`DoublyLinkedList` クラスの可読性、機能性、および保守性が向上します。