### PR TITLE
feat: Expose FindLessThan and FindGreaterThan methods in AvlTree and …

### DIFF
--- a/TAmeAtCoderLibrary/AVLTree.cs
+++ b/TAmeAtCoderLibrary/AVLTree.cs
@@ -89,7 +89,7 @@ public class AvlTree<T> where T : IComparable<T>
     /// <param name="item">基準となる値。</param>
     /// <param name="currentMax">現在の最大値。</param>
     /// <returns>指定した値よりも小さい最大の値を返します。</returns>
-    private T FindLessThan(T item, T currentMax) => RootNode != null ? RootNode.FindLessThan(item, currentMax) : currentMax;
+    public T FindLessThan(T item, T currentMax) => RootNode != null ? RootNode.FindLessThan(item, currentMax) : currentMax;
 
     /// <summary>
     /// 指定した値よりも大きい最小の値を内部的に取得します。
@@ -97,7 +97,7 @@ public class AvlTree<T> where T : IComparable<T>
     /// <param name="item">基準となる値。</param>
     /// <param name="currentMin">現在の最小値。</param>
     /// <returns>指定した値よりも大きい最小の値を返します。</returns>
-    private T FindGreaterThan(T item, T currentMin) => RootNode != null ? RootNode.FindGreaterThan(item, currentMin) : currentMin;
+    public T FindGreaterThan(T item, T currentMin) => RootNode != null ? RootNode.FindGreaterThan(item, currentMin) : currentMin;
 
     /// <summary>
     /// 指定したキー以下の最大のキーを返します。

--- a/TAmeAtCoderLibrary/AVLTreeDictionary.cs
+++ b/TAmeAtCoderLibrary/AVLTreeDictionary.cs
@@ -63,6 +63,22 @@ public class AvlTreeDictionary<T1, T2> where T1 : IComparable<T1>
             dic[key] = value;
     }
 
+    /// <summary>インデクサー - 指定したキーに対応する値を取得または設定します</summary>
+    /// <param name="key">アクセスするキー</param>
+    /// <returns>指定されたキーに対応する値</returns>
+    /// <exception cref="KeyNotFoundException">キーが見つからない場合にスローされます</exception>
+    public T2 this[T1 key]
+    {
+        get => dic[key];
+        set
+        {
+            if (!dic.ContainsKey(key))
+                Add(key, value);
+            else
+                dic[key] = value;
+        }
+    }
+
     /// <summary>指定されたキーとそれに対応する値を辞書から削除します</summary>
     /// <param name="key">削除するキー</param>
     public void Remove(T1 key)
@@ -75,17 +91,17 @@ public class AvlTreeDictionary<T1, T2> where T1 : IComparable<T1>
     /// <param name="key">基準となるキー</param>
     /// <param name="minKey">取得できない場合に返すデフォルト値</param>
     /// <returns>指定されたキーより小さい最大のキー、または存在しない場合はminKey</returns>
-    public T1 GetBelowKey(T1 key, T1 minKey) => avl.GetBelow(key, minKey);
+    public T1 GetBelowKey(T1 key, T1 minKey) => avl.FindLessThan(key, minKey);
 
     /// <summary>指定されたキーより大きい最小のキーを取得します</summary>
     /// <param name="key">基準となるキー</param>
     /// <param name="maxKey">取得できない場合に返すデフォルト値</param>
     /// <returns>指定されたキーより大きい最小のキー、または存在しない場合はmaxKey</returns>
-    public T1 GetNextKey(T1 key, T1 maxKey) => avl.GetNext(key, maxKey);
+    public T1 GetNextKey(T1 key, T1 maxKey) => avl.FindGreaterThan(key, maxKey);
 
     /// <summary>キーを昇順に並べたリストを取得します</summary>
     /// <returns>順序付けされたキーのリスト</returns>
-    public List<T1> InOrderKeys() => avl.InOrder();
+    public List<T1> InOrderKeys() => avl.ToSortedList();
 
     /// <summary>キーの昇順に対応する値のリストを取得します</summary>
     /// <returns>キーの昇順に対応する値のリスト</returns>
@@ -98,5 +114,28 @@ public class AvlTreeDictionary<T1, T2> where T1 : IComparable<T1>
             list2.Add(dic[key]);
 
         return list2;
+    }
+
+    /// <summary>指定されたキーに対応する値を取得します。キーが見つかったかどうかを示す値を返します</summary>
+    /// <param name="key">検索するキー</param>
+    /// <param name="value">指定されたキーに対応する値。キーが存在しない場合はdefault(T2)</param>
+    /// <returns>辞書内に指定されたキーが存在する場合はtrue、それ以外はfalse</returns>
+    public bool TryGetValue(T1 key, out T2 value)
+    {
+        if (dic.ContainsKey(key))
+        {
+            value = dic[key];
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>辞書からすべての要素を削除します</summary>
+    public void Clear()
+    {
+        avl.Clear();
+        dic.Clear();
     }
 }


### PR DESCRIPTION
このプルリクエストには、`TAmeAtCoderLibrary`プロジェクトに対するいくつかの変更が含まれており、`AVLTree`クラスと`AVLTreeDictionary`クラスのアクセシビリティと機能性の向上に重点を置いています。最も重要な変更点は、特定のメソッドをpublicに変更したこと、辞書操作のための新しいメソッドを追加したこと、一貫性のためにファイル名を変更したことです。

### アクセシビリティの改善：
* [`TAmeAtCoderLibrary/AVLTree.cs`](diffhunk://#diff-5601caa06871dd012f4669c49762e810d2085802e554626bef3c425411cf985bL92-R100): `FindLessThan`メソッドと`FindGreaterThan`メソッドのアクセシビリティをprivateからpublicに変更しました。

### 辞書操作のための新しいメソッド：
* [`TAmeAtCoderLibrary/AVLTreeDictionary.cs`](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7R66-R81): キーによる値の取得または設定を行うためのインデクサーを追加しました。キーが存在しない場合は例外が発生します。
* [`TAmeAtCoderLibrary/AVLTreeDictionary.cs`](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7R118-R140): 値の取得を試み、成功したかどうかを示すブール値を返す`TryGetValue`メソッドを追加しました。
* [`TAmeAtCoderLibrary/AVLTreeDictionary.cs`](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7R118-R140): 辞書からすべての要素を削除する`Clear`メソッドを追加しました。

### ファイル名の変更：
* [`TAmeAtCoderLibrary/AVLTreeDictionary.cs`](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7R66-R81): 一貫性を保つために`TAmeAtCoderLibrary/AVLTreeDctionary.cs`から名前を変更しました。 [[1]](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7R66-R81) [[2]](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7L78-R104) [[3]](diffhunk://#diff-acf76c42c371798ac702746fc0bb07bcffa23c714c2b8534eb7d027e8fc5ecc7R118-R140)