### PR TITLE
fix: `UnionFindTree.cs` の名前空間を `TAmeAtCoderLibrary` に変更

### DIFF
--- a/TAmeAtCoderLibrary/UnionFindTree.cs
+++ b/TAmeAtCoderLibrary/UnionFindTree.cs
@@ -1,7 +1,7 @@
-#nullable enable 
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
 
-namespace TJAtCoderLibs;
+namespace TAmeAtCoderLibrary;
 
 /// <summary>
 /// Union-Find Tree (Disjoint Set Union) データ構造。


### PR DESCRIPTION
このプルリクエストは、`TAmeAtCoderLibrary/UnionFindTree.cs` ファイルの名前空間を、適切なライブラリ名に修正する変更を含みます。

* [`TAmeAtCoderLibrary/UnionFindTree.cs`](diffhunk://#diff-cad4cf6af942cdf01de3997a424fe1d3dbf51602943c35d1ac87e57b9012a09fL4-R4): 正しいライブラリ名を反映するため、名前空間を `TJAtCoderLibs` から `TAmeAtCoderLibrary` へ変更しました。