### PR TITLE
feat(Graph): SimpleDirectedGraph/SimpleUndirectedGraph のAPI統一と改善

### DIFF
--- a/TAmeAtCoderLibrary/SimpleDirectedGraph.cs
+++ b/TAmeAtCoderLibrary/SimpleDirectedGraph.cs
@@ -2,10 +2,10 @@
 using System.Collections.ObjectModel;
 
 namespace TAmeAtCoderLibrary;
-
 /// <summary>
-/// 重み付き単純有向グラフを表します。
-/// 頂点はint型、辺の重みはlong型で表現されます。
+/// 頂点が非負整数で識別され、辺が長整数の重みを持つことができる単純有向グラフを表します。
+/// このグラフは自己ループを許可しません。
+/// 重みが指定されない場合、デフォルトで 1 が設定されます（TryAddEdge使用時）。
 /// </summary>
 public class SimpleDirectedGraph
 {
@@ -33,10 +33,12 @@ public class SimpleDirectedGraph
 
     /// <summary>
     /// 辺の配列から単純有向グラフを生成します。
+    /// 各辺はデフォルトの重み 1 で追加され、既に存在する辺は無視されます。自己ループも無視されます。
     /// </summary>
-    /// <param name="edges">辺の配列。各要素は {from, to} (重み1) または {from, to, weight} の形式です。</param>
-    /// <exception cref="ArgumentNullException">edgesがnullの場合。</exception>
-    /// <exception cref="ArgumentException">辺の配列の形式が不正な場合にスローされます。</exception>
+    /// <param name="edges">辺の配列。各要素は {from, to} または {from, to, weight} の形式です。weightが指定された場合はその値が使われます。</param>
+    /// <exception cref="ArgumentNullException"><paramref name="edges"/>がnullの場合。</exception>
+    /// <exception cref="ArgumentException"><paramref name="edges"/>内の配列形式が不正な場合。</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="edges"/>内に負の頂点IDが含まれる場合。</exception>
     public SimpleDirectedGraph(int[][] edges)
     {
         AddEdges(edges);
@@ -45,10 +47,14 @@ public class SimpleDirectedGraph
     /// <summary>
     /// グラフに頂点を追加します。既に存在する場合は何もしません。
     /// </summary>
-    /// <param name="vertex">追加する頂点。</param>
+    /// <param name="vertex">追加する頂点のID。非負である必要があります。</param>
     /// <returns>頂点が新しく追加された場合は true、既に存在した場合は false。</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="vertex"/>が負の場合。</exception>
     public bool AddVertex(int vertex)
     {
+        if (vertex < 0)
+            throw new ArgumentOutOfRangeException(nameof(vertex), "Vertex ID cannot be negative.");
+
         if (_adjacencyList.TryAdd(vertex, new Dictionary<int, long>()))
         {
             _inDegrees.TryAdd(vertex, 0); // 新しい頂点の入次数は0
@@ -59,61 +65,70 @@ public class SimpleDirectedGraph
 
     /// <summary>
     /// グラフに複数の辺を追加します。
+    /// 辺が存在しない場合は追加され、既に存在する場合は無視されます。自己ループも無視されます。
+    /// 重みが指定されていない場合はデフォルトで 1 が使用されます。
     /// </summary>
     /// <param name="edges">辺の配列。各要素は {from, to} (重み1) または {from, to, weight} の形式です。</param>
-    /// <exception cref="ArgumentNullException">edgesがnullの場合。</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="edges"/>がnullの場合。</exception>
     /// <exception cref="ArgumentException">辺の配列の形式が不正な場合にスローされます。</exception>
+    /// <exception cref="ArgumentOutOfRangeException">頂点IDが負の場合。</exception>
     public void AddEdges(int[][] edges)
     {
-        if (edges == null) throw new ArgumentNullException(nameof(edges));
+        ArgumentNullException.ThrowIfNull(edges);
 
         foreach (var edge in edges)
         {
             if (edge == null || edge.Length < 2 || edge.Length > 3)
             {
-                throw new ArgumentException("各辺の配列は {from, to} または {from, to, weight} の形式である必要があります。", nameof(edges));
+                throw new ArgumentException("Each edge array must be in the format {from, to} or {from, to, weight}.", nameof(edges));
             }
 
             int from = edge[0];
             int to = edge[1];
-            long weight = (edge.Length == 3) ? edge[2] : 1L;
-            AddEdge(from, to, weight);
+            long weight = (edge.Length == 3) ? edge[2] : 1L; // デフォルト重み 1L
+
+            // TryAddEdge を使用して、存在しない場合のみ追加
+            TryAddEdge(from, to, weight);
         }
     }
 
     /// <summary>
-    /// グラフに重み 1 の辺を追加します。
+    /// グラフに重み 1 の辺を追加または更新します。
     /// 頂点が存在しない場合は自動的に追加されます。
-    /// 既に辺が存在する場合は重みが 1 に上書きされます。
+    /// 自己ループは無視されます。
     /// </summary>
-    /// <remarks>
-    /// このオーバーロードは、<see cref="AddEdges(int[][])"/> メソッドで重みが省略された場合の挙動と一貫性を持たせるため、
-    /// デフォルトの重みを 1L として扱います。
-    /// </remarks>
-    /// <param name="from">辺の始点。</param>
-    /// <param name="to">辺の終点。</param>
+    /// <param name="from">辺の始点のID。非負である必要があります。</param>
+    /// <param name="to">辺の終点のID。非負である必要があります。</param>
+    /// <exception cref="ArgumentOutOfRangeException">頂点IDが負の場合。</exception>
     public void AddEdge(int from, int to)
     {
-        // AddEdges(int[][]) との一貫性のため、デフォルトの重みは 1L とする
-        AddEdge(from, to, 1L);
+        AddOrUpdateEdge(from, to, 1L);
     }
 
     /// <summary>
-    /// グラフに重み付きの辺を追加します。
+    /// グラフに重み付きの辺を追加または更新します。
     /// 頂点が存在しない場合は自動的に追加されます。
-    /// 既に辺が存在する場合は重みが上書きされます。
+    /// 自己ループは無視されます。
     /// </summary>
-    /// <param name="from">辺の始点。</param>
-    /// <param name="to">辺の終点。</param>
+    /// <param name="from">辺の始点のID。非負である必要があります。</param>
+    /// <param name="to">辺の終点のID。非負である必要があります。</param>
     /// <param name="weight">辺の重み。</param>
-    public void AddEdge(int from, int to, long weight)
+    /// <exception cref="ArgumentOutOfRangeException">頂点IDが負の場合。</exception>
+    public void AddOrUpdateEdge(int from, int to, long weight)
     {
+        // 自己ループは許可しない
+        if (from == to) return;
+        if (from < 0) throw new ArgumentOutOfRangeException(nameof(from), "Vertex ID cannot be negative.");
+        if (to < 0) throw new ArgumentOutOfRangeException(nameof(to), "Vertex ID cannot be negative.");
+
         // 頂点が存在しない場合は追加
-        AddVertex(from);
-        AddVertex(to);
+        AddVertex(from); // 内部で存在チェックするので TryAdd 不要
+        AddVertex(to);   // 内部で存在チェックするので TryAdd 不要
+
+        // 辺が既に存在したかを確認 (入次数と辺数更新のため)
+        bool edgeExisted = _adjacencyList[from].ContainsKey(to);
 
         // 辺を追加または更新
-        bool edgeExisted = _adjacencyList[from].ContainsKey(to);
         _adjacencyList[from][to] = weight;
 
         // 辺が新しく追加された場合のみ入次数と辺数を更新
@@ -125,51 +140,87 @@ public class SimpleDirectedGraph
     }
 
     /// <summary>
+    /// グラフに重み付きの辺を追加しようと試みます。
+    /// 頂点が存在しない場合は自動的に追加されます。
+    /// 辺が既に存在する場合、または自己ループになる場合は、このメソッドは何もしません。
+    /// </summary>
+    /// <param name="from">辺の始点のID。非負である必要があります。</param>
+    /// <param name="to">辺の終点のID。非負である必要があります。</param>
+    /// <param name="weight">辺の重み。</param>
+    /// <returns>辺が新しく追加された場合は true、それ以外の場合は false。</returns>
+    /// <exception cref="ArgumentOutOfRangeException">頂点IDが負の場合。</exception>
+    public bool TryAddEdge(int from, int to, long weight)
+    {
+        // 自己ループは許可しない
+        if (from == to) return false;
+        if (from < 0) throw new ArgumentOutOfRangeException(nameof(from), "Vertex ID cannot be negative.");
+        if (to < 0) throw new ArgumentOutOfRangeException(nameof(to), "Vertex ID cannot be negative.");
+
+        // 頂点が存在しない場合は追加
+        AddVertex(from);
+        AddVertex(to);
+
+        // 辺を追加しようと試みる
+        if (_adjacencyList[from].TryAdd(to, weight))
+        {
+            // 追加に成功した場合のみ入次数と辺数を更新
+            _inDegrees[to] = _inDegrees.GetValueOrDefault(to, 0) + 1;
+            EdgeCount++;
+            return true;
+        }
+        return false;
+    }
+
+
+    /// <summary>
     /// 辺の重みを取得します。
     /// </summary>
-    /// <param name="from">辺の始点。</param>
-    /// <param name="to">辺の終点。</param>
+    /// <param name="from">辺の始点のID。</param>
+    /// <param name="to">辺の終点のID。</param>
     /// <returns>辺の重み。</returns>
-    /// <exception cref="KeyNotFoundException">指定された辺が存在しない場合にスローされます。</exception>
-    public long GetWeight(int from, int to)
+    /// <exception cref="KeyNotFoundException">指定された頂点または辺が存在しない場合にスローされます。</exception>
+    public long GetEdgeWeight(int from, int to)
     {
-        if (_adjacencyList.TryGetValue(from, out var neighbors) && neighbors.TryGetValue(to, out var weight))
+        if (!_adjacencyList.TryGetValue(from, out var neighbors))
+            throw new KeyNotFoundException($"Vertex {from} does not exist in the graph.");
+        if (neighbors.TryGetValue(to, out var weight))
         {
             return weight;
         }
-        throw new KeyNotFoundException($"辺 ({from} -> {to}) は存在しません。");
+        throw new KeyNotFoundException($"Edge ({from} -> {to}) does not exist.");
     }
 
     /// <summary>
     /// 辺の重みを安全に取得します。
     /// </summary>
-    /// <param name="from">辺の始点。</param>
-    /// <param name="to">辺の終点。</param>
+    /// <param name="from">辺の始点のID。</param>
+    /// <param name="to">辺の終点のID。</param>
     /// <param name="weight">辺が存在する場合、その重みが設定されます。</param>
     /// <returns>辺が存在する場合は true、存在しない場合は false。</returns>
-    public bool TryGetWeight(int from, int to, out long weight)
+    public bool TryGetEdgeWeight(int from, int to, out long weight)
     {
         weight = default;
+        // 頂点の存在も暗黙的にチェックされる
         return _adjacencyList.TryGetValue(from, out var neighbors) && neighbors.TryGetValue(to, out weight);
     }
-
 
     /// <summary>
     /// 辺が存在するかどうかを確認します。
     /// </summary>
-    /// <param name="from">辺の始点。</param>
-    /// <param name="to">辺の終点。</param>
+    /// <param name="from">辺の始点のID。</param>
+    /// <param name="to">辺の終点のID。</param>
     /// <returns>辺が存在する場合は true、存在しない場合は false。</returns>
     public bool ContainsEdge(int from, int to)
     {
+        if (from == to) return false; // 自己ループは存在しない
         return _adjacencyList.TryGetValue(from, out var neighbors) && neighbors.ContainsKey(to);
     }
 
     /// <summary>
-    /// 頂点が存在するかどうかを確認します。
+    /// 頂点がグラフに存在するかどうかを確認します。
     /// </summary>
-    /// <param name="vertex">確認する頂点。</param>
-    /// <returns>頂点が存在する場合は true、存在しない場合は false。</returns>
+    /// <param name="vertex">確認する頂点のID。</param>
+    /// <returns>頂点が存在する場合はtrue、それ以外の場合はfalse。</returns>
     public bool ContainsVertex(int vertex)
     {
         return _adjacencyList.ContainsKey(vertex);
@@ -178,17 +229,21 @@ public class SimpleDirectedGraph
     /// <summary>
     /// グラフから辺を削除します。
     /// </summary>
-    /// <param name="from">辺の始点。</param>
-    /// <param name="to">辺の終点。</param>
+    /// <param name="from">辺の始点のID。</param>
+    /// <param name="to">辺の終点のID。</param>
     /// <returns>辺が削除された場合は true、辺が存在しなかった場合は false。</returns>
     public bool RemoveEdge(int from, int to)
     {
+        // 自己ループ削除の試みは常にfalse
+        if (from == to) return false;
+
         if (_adjacencyList.TryGetValue(from, out var neighbors))
         {
             if (neighbors.Remove(to))
             {
                 // 辺が存在した場合のみ入次数と辺数を更新
-                _inDegrees[to]--; // 存在しないキーアクセスは通常エラーだが、辺があればtoも存在するはず
+                // _inDegreesにtoが存在しないことは通常ないはず
+                _inDegrees[to]--;
                 EdgeCount--;
                 return true;
             }
@@ -196,17 +251,16 @@ public class SimpleDirectedGraph
         return false;
     }
 
-    // Note: 頂点の削除は実装が複雑になるため除外 (必要なら追加実装)
+    // Note: 頂点の削除(RemoveVertex)は実装が複雑になるため除外 (依存辺の削除、入次数/出次数の更新など)
     // public bool RemoveVertex(int vertex) { ... }
 
     /// <summary>
-    /// グラフに含まれるすべての頂点を取得します。
+    /// グラフに含まれるすべての頂点IDを取得します。
     /// 返されるコレクションは読み取り専用です。
     /// </summary>
-    /// <returns>グラフの頂点の読み取り専用コレクション。</returns>
-    public IReadOnlyCollection<int> GetAllVertices()
+    /// <returns>グラフの頂点IDの読み取り専用コレクション。</returns>
+    public IReadOnlyCollection<int> GetVertices()
     {
-        // Keys は直接変更できないため、そのまま返しても安全。
         return _adjacencyList.Keys;
     }
 
@@ -214,16 +268,14 @@ public class SimpleDirectedGraph
     /// 指定された頂点から出ていく辺の終点（隣接頂点）を取得します。
     /// 返されるコレクションは読み取り専用です。
     /// </summary>
-    /// <param name="sourceVertex">始点となる頂点。</param>
-    /// <returns>隣接する頂点の読み取り専用コレクション。頂点が存在しない場合は空のコレクション。</returns>
-    public IReadOnlyCollection<int> GetAdjacentVertices(int sourceVertex)
+    /// <param name="vertex">始点となる頂点のID。</param>
+    /// <returns>隣接する頂点のIDを含む読み取り専用コレクション。頂点が存在しない場合は空のコレクション。</returns>
+    public IReadOnlyCollection<int> GetNeighbors(int vertex)
     {
-        if (_adjacencyList.TryGetValue(sourceVertex, out var neighbors))
+        if (_adjacencyList.TryGetValue(vertex, out var neighbors))
         {
-            // Keys は直接変更できないため、そのまま返しても安全。
             return neighbors.Keys;
         }
-        // .NET Core 2.0以降では Array.Empty<T>() が推奨されることが多い
         return Array.Empty<int>();
     }
 
@@ -231,28 +283,39 @@ public class SimpleDirectedGraph
     /// 指定された頂点から出ていく辺（隣接頂点とその重み）を取得します。
     /// 返される辞書は読み取り専用です。
     /// </summary>
-    /// <param name="sourceVertex">始点となる頂点。</param>
+    /// <param name="vertex">始点となる頂点のID。</param>
     /// <returns>隣接する頂点と重みのペアの読み取り専用辞書。頂点が存在しない場合は空の辞書。</returns>
-    public IReadOnlyDictionary<int, long> GetOutgoingEdges(int sourceVertex)
+    public IReadOnlyDictionary<int, long> GetOutgoingEdges(int vertex)
     {
-        if (_adjacencyList.TryGetValue(sourceVertex, out var neighbors))
+        if (_adjacencyList.TryGetValue(vertex, out var neighbors))
         {
-            // Dictionaryをそのまま返すと外部で変更できてしまうため、ReadOnlyDictionaryでラップ
             return new ReadOnlyDictionary<int, long>(neighbors);
         }
-        // 空のReadOnlyDictionaryを返す
         return new ReadOnlyDictionary<int, long>(new Dictionary<int, long>());
     }
 
     /// <summary>
     /// 指定された頂点の入次数（その頂点に入る辺の数）を取得します。
     /// </summary>
-    /// <param name="vertex">入次数を調べる頂点。</param>
+    /// <param name="vertex">入次数を調べる頂点のID。</param>
     /// <returns>頂点の入次数。頂点が存在しない場合は 0。</returns>
     public int GetInDegree(int vertex)
     {
-        // 存在しないキーでも 0 を返す
         return _inDegrees.GetValueOrDefault(vertex, 0);
+    }
+
+    /// <summary>
+    /// 指定された頂点の出次数（その頂点から出る辺の数）を取得します。
+    /// </summary>
+    /// <param name="vertex">出次数を調べる頂点のID。</param>
+    /// <returns>頂点の出次数。頂点が存在しない場合は 0。</returns>
+    public int GetOutDegree(int vertex)
+    {
+        if (_adjacencyList.TryGetValue(vertex, out var neighbors))
+        {
+            return neighbors.Count;
+        }
+        return 0;
     }
 
     /// <summary>
@@ -262,34 +325,33 @@ public class SimpleDirectedGraph
     public SimpleDirectedGraph GenerateReversed()
     {
         var reversedGraph = new SimpleDirectedGraph();
-        foreach (var vertex in GetAllVertices())
+        // 全ての頂点をまず追加 (孤立点もコピーするため)
+        foreach (var vertex in GetVertices())
         {
-            reversedGraph.AddVertex(vertex); // 全ての頂点を追加
+            reversedGraph.AddVertex(vertex);
         }
-
-        foreach (var kvp in _adjacencyList) // KeyValuePair<int, Dictionary<int, long>>
+        // 辺を逆向きに追加 (TryAddEdgeを使う)
+        foreach (var kvp in _adjacencyList)
         {
             int fromVertex = kvp.Key;
-            foreach (var edge in kvp.Value) // KeyValuePair<int, long>
+            foreach (var edge in kvp.Value)
             {
                 int toVertex = edge.Key;
                 long weight = edge.Value;
-                // 辺の向きを逆にして追加
-                reversedGraph.AddEdge(toVertex, fromVertex, weight);
+                reversedGraph.TryAddEdge(toVertex, fromVertex, weight); // AddOrUpdateEdge でも可
             }
         }
         return reversedGraph;
     }
 
     // --- 閉路検出 (Cycle Detection) ---
-
     private enum VisitState { Unvisited, Visiting, Visited }
 
     /// <summary>
     /// グラフ内に閉路（サイクル）が存在するかどうかを検出します。
     /// </summary>
     /// <returns>閉路が存在する場合は true、存在しない場合は false。</returns>
-    public bool HasCycle()
+    public bool ContainsCycle()
     {
         return TryFindCycle(out _);
     }
@@ -300,15 +362,14 @@ public class SimpleDirectedGraph
     /// </summary>
     /// <param name="cyclePath">検出された閉路の頂点のリスト（順序付き）。閉路が存在しない場合は null。</param>
     /// <returns>閉路が検出された場合は true、存在しない場合は false。</returns>
-    public bool TryFindCycle(out List<int>? cyclePath) // CS8632 修正: #nullable enable があればOK
+    public bool TryFindCycle(out List<int>? cyclePath)
     {
         var visitState = new Dictionary<int, VisitState>();
         var recursionStack = new Stack<int>(); // 現在の探索パス
 
-        foreach (int vertex in GetAllVertices())
+        foreach (int vertex in GetVertices())
         {
-            // まだ訪問状態が記録されていない頂点から探索開始
-            if (!visitState.ContainsKey(vertex)) // Unvisited と同じ扱い
+            if (!visitState.ContainsKey(vertex)) // Unvisitedと同じ扱い
             {
                 if (TryFindCycleDfs(vertex, visitState, recursionStack, out cyclePath))
                 {
@@ -322,40 +383,37 @@ public class SimpleDirectedGraph
     }
 
     // 閉路検出のDFSヘルパー
-    private bool TryFindCycleDfs(int currentVertex, Dictionary<int, VisitState> visitState, Stack<int> recursionStack, out List<int>? cyclePath) // CS8632 修正
+    private bool TryFindCycleDfs(int currentVertex, Dictionary<int, VisitState> visitState, Stack<int> recursionStack, out List<int>? cyclePath)
     {
         visitState[currentVertex] = VisitState.Visiting;
         recursionStack.Push(currentVertex);
 
-        // 隣接頂点をループで処理する前に、頂点が存在するか確認（GetAllVerticesで取得した後、辺が削除された場合などへの対策）
-        if (_adjacencyList.TryGetValue(currentVertex, out var neighbors))
+        // GetNeighbors を使用して隣接頂点を取得
+        foreach (var neighbor in GetNeighbors(currentVertex))
         {
-            foreach (var neighbor in neighbors.Keys) // GetAdjacentVertices(currentVertex) の中身を展開
-            {
-                VisitState neighborState = visitState.GetValueOrDefault(neighbor, VisitState.Unvisited);
+            VisitState neighborState = visitState.GetValueOrDefault(neighbor, VisitState.Unvisited);
 
-                if (neighborState == VisitState.Unvisited)
+            if (neighborState == VisitState.Unvisited)
+            {
+                if (TryFindCycleDfs(neighbor, visitState, recursionStack, out cyclePath))
                 {
-                    if (TryFindCycleDfs(neighbor, visitState, recursionStack, out cyclePath))
-                    {
-                        return true; // 再帰呼び出しで閉路が見つかった
-                    }
+                    return true; // 再帰呼び出しで閉路が見つかった
                 }
-                else if (neighborState == VisitState.Visiting)
-                {
-                    // 訪問中の頂点に戻ってきた -> 閉路発見
-                    cyclePath = new List<int>();
-                    // スタックから閉路部分を抽出
-                    foreach (int node in recursionStack.Reverse()) // StackはLIFOなのでReverseが必要
-                    {
-                        cyclePath.Add(node);
-                        if (node == neighbor) break; // 閉路の開始点まで追加したら終了
-                    }
-                    cyclePath.Reverse(); // 始点から終点の順序にする
-                    return true;
-                }
-                // neighborState == VisitState.Visited の場合はスキップ
             }
+            else if (neighborState == VisitState.Visiting)
+            {
+                // 訪問中の頂点に戻ってきた -> 閉路発見
+                cyclePath = new List<int>();
+                // スタックから閉路部分を抽出
+                foreach (int node in recursionStack.Reverse()) // StackはLIFOなのでReverseが必要
+                {
+                    cyclePath.Add(node);
+                    if (node == neighbor) break; // 閉路の開始点まで追加したら終了
+                }
+                cyclePath.Reverse(); // 始点から終点の順序にする
+                return true;
+            }
+            // neighborState == VisitState.Visited の場合はスキップ
         }
 
         // この頂点からの探索が完了（閉路は見つからなかった）
@@ -374,7 +432,7 @@ public class SimpleDirectedGraph
     /// </summary>
     /// <param name="sortedVertices">トポロジカルソートされた頂点のリスト。閉路が存在する場合は null。</param>
     /// <returns>トポロジカルソートが成功した（閉路がなかった）場合は true、閉路が存在した場合は false。</returns>
-    public bool TryTopologicalSort(out List<int>? sortedVertices) // CS8632 修正
+    public bool TryTopologicalSort(out List<int>? sortedVertices)
     {
         return TryTopologicalSortInternal(false, out sortedVertices);
     }
@@ -385,39 +443,32 @@ public class SimpleDirectedGraph
     /// </summary>
     /// <param name="sortedVertices">辞書順最小でトポロジカルソートされた頂点のリスト。閉路が存在する場合は null。</param>
     /// <returns>トポロジカルソートが成功した（閉路がなかった）場合は true、閉路が存在した場合は false。</returns>
-    public bool TryTopologicalSortLexicographical(out List<int>? sortedVertices) // CS8632 修正
+    public bool TryTopologicalSortLexicographical(out List<int>? sortedVertices)
     {
         return TryTopologicalSortInternal(true, out sortedVertices);
     }
 
-    /// <summary>
-    /// トポロジカルソートの内部実装。
-    /// </summary>
-    private bool TryTopologicalSortInternal(bool lexicographical, out List<int>? sortedVertices) // CS8632 修正
+    // トポロジカルソートの内部実装
+    private bool TryTopologicalSortInternal(bool lexicographical, out List<int>? sortedVertices)
     {
         sortedVertices = new List<int>();
-        var currentInDegrees = new Dictionary<int, int>(_inDegrees); // 入次数のコピーを作成して操作
+        var currentInDegrees = new Dictionary<int, int>(_inDegrees); // 入次数のコピーを作成
         object zeroInDegreeQueue = InitializeZeroInDegreeQueue(lexicographical, currentInDegrees); // 型はobject
 
-        // CS0019 修正: 型に応じてCountプロパティにアクセスし、ループ条件とする
         while (GetQueueCount(zeroInDegreeQueue, lexicographical) > 0)
         {
             int currentVertex = DequeueFrom(zeroInDegreeQueue, lexicographical);
             sortedVertices.Add(currentVertex);
 
-            // 隣接頂点の入次数を減らす
-            if (_adjacencyList.TryGetValue(currentVertex, out var neighbors))
+            // 隣接頂点の入次数を減らす (GetNeighborsを使用)
+            foreach (var neighbor in GetNeighbors(currentVertex))
             {
-                foreach (var neighbor in neighbors.Keys)
+                if (currentInDegrees.ContainsKey(neighbor)) // 念のため確認
                 {
-                    // currentInDegreesにneighborが存在しないケースは基本的にないはずだが念のため
-                    if (currentInDegrees.ContainsKey(neighbor))
+                    currentInDegrees[neighbor]--;
+                    if (currentInDegrees[neighbor] == 0)
                     {
-                        currentInDegrees[neighbor]--;
-                        if (currentInDegrees[neighbor] == 0)
-                        {
-                            EnqueueTo(zeroInDegreeQueue, neighbor, lexicographical);
-                        }
+                        EnqueueTo(zeroInDegreeQueue, neighbor, lexicographical);
                     }
                 }
             }
@@ -431,45 +482,40 @@ public class SimpleDirectedGraph
         else
         {
             // 閉路が存在するため、ソートは不完全
-            sortedVertices = null; // Null許容型なので代入可能
+            sortedVertices = null;
             return false;
         }
     }
 
-    // キュー/優先度付きキューの要素数を取得するヘルパー (CS0019 対策)
+    // キュー/優先度付きキューの要素数を取得するヘルパー
     private int GetQueueCount(object queue, bool lexicographical)
     {
-        if (lexicographical)
-        {
-            // PriorityQueue<TElement, TPriority> にキャスト
-            return ((PriorityQueue<int, int>)queue).Count;
-        }
-        else
-        {
-            // Queue<T> にキャスト
-            return ((Queue<int>)queue).Count;
-        }
+        return lexicographical
+            ? ((PriorityQueue<int, int>)queue).Count
+            : ((Queue<int>)queue).Count;
     }
-
 
     // トポロジカルソート用のキュー/優先度付きキュー初期化ヘルパー
     private object InitializeZeroInDegreeQueue(bool lexicographical, Dictionary<int, int> currentInDegrees)
     {
-        var sources = GetAllVertices().Where(v => currentInDegrees.GetValueOrDefault(v, 0) == 0);
+        // 入次数0の頂点を抽出
+        var sources = GetVertices().Where(v => currentInDegrees.GetValueOrDefault(v, 0) == 0);
+
         if (lexicographical)
         {
-            // 辞書順の場合はPriorityQueue (Min-Heapとして使用)
-            var pq = new PriorityQueue<int, int>(); // C# 6.0 以降
-            foreach (var vertex in sources.OrderBy(v => v)) // 念のためOrderByを追加
+            // 辞書順の場合はPriorityQueue (Min-Heap)
+            var pq = new PriorityQueue<int, int>();
+            // OrderByは不要 (PriorityQueueが順序を管理)
+            foreach (var vertex in sources)
             {
-                pq.Enqueue(vertex, vertex); // 優先度も頂点IDそのもの
+                pq.Enqueue(vertex, vertex); // 優先度も頂点ID
             }
             return pq;
         }
         else
         {
-            // 通常はQueueで良い
-            return new Queue<int>(sources); // QueueのコンストラクタはIEnumerableを受け取れる
+            // 通常はQueue
+            return new Queue<int>(sources);
         }
     }
 
@@ -477,26 +523,17 @@ public class SimpleDirectedGraph
     private void EnqueueTo(object queue, int vertex, bool lexicographical)
     {
         if (lexicographical)
-        {
             ((PriorityQueue<int, int>)queue).Enqueue(vertex, vertex);
-        }
         else
-        {
             ((Queue<int>)queue).Enqueue(vertex);
-        }
     }
 
     // トポロジカルソート用のキュー/優先度付きキューからの取り出しヘルパー
     private int DequeueFrom(object queue, bool lexicographical)
     {
-        if (lexicographical)
-        {
-            return ((PriorityQueue<int, int>)queue).Dequeue();
-        }
-        else
-        {
-            return ((Queue<int>)queue).Dequeue();
-        }
+        return lexicographical
+            ? ((PriorityQueue<int, int>)queue).Dequeue()
+            : ((Queue<int>)queue).Dequeue();
     }
 
 
@@ -506,23 +543,25 @@ public class SimpleDirectedGraph
     /// ダイクストラ法を用いて、指定された始点から他の全ての頂点への最短経路コストを計算します。
     /// 負の重みを持つ辺が存在する場合、正しい結果が得られない可能性があります。
     /// </summary>
-    /// <param name="startVertex">始点となる頂点。</param>
+    /// <param name="startVertex">始点となる頂点のID。非負である必要があります。</param>
     /// <returns>
     /// 各頂点への最短経路コストを格納した辞書。
-    /// 始点から到達不可能な頂点は含まれません。
+    /// キーは頂点ID、値は始点からの最短コストです。
+    /// 始点から到達不可能な頂点は辞書に含まれません。
     /// 始点自身のコストは 0 です。
     /// </returns>
-    /// <exception cref="KeyNotFoundException">始点が存在しない場合にスローされます。</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="startVertex"/>が負の場合。</exception>
+    /// <exception cref="KeyNotFoundException">始点<paramref name="startVertex"/>がグラフに存在しない場合。</exception>
     public Dictionary<int, long> Dijkstra(int startVertex)
     {
+        if (startVertex < 0)
+            throw new ArgumentOutOfRangeException(nameof(startVertex), "Vertex ID cannot be negative.");
         if (!ContainsVertex(startVertex))
-        {
-            throw new KeyNotFoundException($"始点 {startVertex} はグラフに存在しません。");
-        }
+            throw new KeyNotFoundException($"Start vertex {startVertex} does not exist in the graph.");
 
-        var costs = new Dictionary<int, long>(); // 始点からの最短コスト
+        var costs = new Dictionary<int, long>(); // 始点からの確定した最短コスト
                                                  // 優先度付きキュー: {頂点, 始点からの暫定コスト} コストが小さい順に取り出す
-        var priorityQueue = new PriorityQueue<int, long>(); // C# 6.0 以降
+        var priorityQueue = new PriorityQueue<int, long>();
 
         // 初期化
         costs[startVertex] = 0L;
@@ -531,6 +570,7 @@ public class SimpleDirectedGraph
         while (priorityQueue.TryDequeue(out int currentVertex, out long currentCost))
         {
             // キューから取り出したコストが、記録されている最短コストより大きい場合はスキップ
+            // (より短い経路が既に見つかっている場合)
             if (costs.TryGetValue(currentVertex, out long recordedCost) && currentCost > recordedCost)
             {
                 continue;
@@ -542,13 +582,16 @@ public class SimpleDirectedGraph
                 int neighbor = edge.Key;
                 long weight = edge.Value;
 
-                // 負の重みチェック (任意)
-                // if (weight < 0) throw new InvalidOperationException("Dijkstra cannot handle negative weights.");
+                // 負の重みチェック（ダイクストラ法の前提）
+                // if (weight < 0) throw new InvalidOperationException("Dijkstra algorithm cannot handle negative weights.");
 
                 long newCost = currentCost + weight;
 
-                // オーバーフローチェック (任意、非常に大きなコストの場合)
-                // if (newCost < currentCost) { /* Handle overflow, e.g., treat as infinity */ newCost = long.MaxValue; }
+                // オーバーフローチェック (任意、longの最大値を超えるような巨大なコストの場合)
+                if (currentCost > 0 && weight > 0 && newCost < currentCost)
+                {
+                    newCost = long.MaxValue; // または他のオーバーフロー処理
+                }
 
 
                 // 既に記録されているコストより小さい場合、またはまだコストが記録されていない場合
@@ -559,7 +602,6 @@ public class SimpleDirectedGraph
                 }
             }
         }
-
         return costs;
     }
 
@@ -567,23 +609,24 @@ public class SimpleDirectedGraph
     /// ダイクストラ法を用いて、始点から終点への最短経路コストを計算します。
     /// 負の重みを持つ辺が存在する場合、正しい結果が得られない可能性があります。
     /// </summary>
-    /// <param name="startVertex">始点となる頂点。</param>
-    /// <param name="endVertex">終点となる頂点。</param>
+    /// <param name="startVertex">始点となる頂点のID。非負である必要があります。</param>
+    /// <param name="endVertex">終点となる頂点のID。非負である必要があります。</param>
     /// <returns>始点から終点への最短経路コスト。到達不可能な場合は long.MaxValue。</returns>
-    /// <exception cref="KeyNotFoundException">始点または終点が存在しない場合にスローされます。</exception>
+    /// <exception cref="ArgumentOutOfRangeException">頂点IDが負の場合。</exception>
+    /// <exception cref="KeyNotFoundException">始点または終点がグラフに存在しない場合。</exception>
     public long Dijkstra(int startVertex, int endVertex)
     {
+        if (startVertex < 0)
+            throw new ArgumentOutOfRangeException(nameof(startVertex), "Vertex ID cannot be negative.");
+        if (endVertex < 0)
+            throw new ArgumentOutOfRangeException(nameof(endVertex), "Vertex ID cannot be negative.");
         if (!ContainsVertex(startVertex))
-        {
-            throw new KeyNotFoundException($"始点 {startVertex} はグラフに存在しません。");
-        }
+            throw new KeyNotFoundException($"Start vertex {startVertex} does not exist in the graph.");
         if (!ContainsVertex(endVertex))
-        {
-            throw new KeyNotFoundException($"終点 {endVertex} はグラフに存在しません。");
-        }
+            throw new KeyNotFoundException($"End vertex {endVertex} does not exist in the graph.");
 
-        // 最適化: 終点に到達した時点で探索を打ち切る実装も可能。
-        // ここでは、全頂点へのコスト計算後に結果を取得する。
+        // 最適化: 終点に到達した時点で探索を打ち切るダイクストラ法の実装も可能だが、
+        // ここでは全頂点へのコスト計算後に結果を取得するシンプルな方法を採用。
         var allCosts = Dijkstra(startVertex);
 
         if (allCosts.TryGetValue(endVertex, out long cost))


### PR DESCRIPTION
### 概要

`SimpleDirectedGraph` クラスと `SimpleUndirectedGraph` クラスにおいて、APIの統一性を高め、全体的な機能改善とコード品質の向上を目的とした変更を行いました。
これにより、両クラスの一貫性が向上し、より直感的で堅牢な利用が可能になります。

### 背景・目的

既存の `SimpleDirectedGraph` と `SimpleUndirectedGraph` の実装において、類似する機能に対するメソッド名やデフォルトの挙動（特に辺の重み）に差異が存在していました。また、一部のメソッドで引数チェックや例外処理、ドキュメントコメントが不十分な箇所がありました。
このプルリクエストは、これらの点を改善し、利用者にとって一貫性があり、信頼性の高いグラフライブラリを提供することを目的としています。

### 主な変更点

#### 1. APIの統一化

両クラス間で共通する機能について、メソッド名や挙動を統一しました。

- **辺の重み取得:** `GetWeight` / `TryGetWeight` を `GetEdgeWeight` / `TryGetEdgeWeight` に統一しました。
- **頂点リスト取得:** `GetAllVertices` を `GetVertices` に統一しました。
- **隣接頂点取得:** `GetAdjacentVertices` を `GetNeighbors` に統一しました。
- **閉路検出:** `HasCycle` を `ContainsCycle` に統一しました。

#### 2. `SimpleDirectedGraph` の改善

- **辺追加メソッドの挙動整理:**
    - `AddEdge(from, to)`: デフォルト重み `1L` で辺を追加、または**更新**する挙動に変更しました（内部で `AddOrUpdateEdge` を利用）。
    - `AddEdge(from, to, weight)` を `AddOrUpdateEdge(from, to, weight)` にリネームし、辺が存在する場合に重みを**更新**する挙動を明確にしました。
    - `TryAddEdge(from, to, weight)`: 辺が存在しない場合にのみ追加するメソッドとしての役割を明確化しました。
- **`GetOutDegree(vertex)` メソッドの追加:** 指定した頂点の出次数（出ていく辺の数）を取得する機能を追加しました。
- **自己ループの明示的な禁止:** 辺追加/更新時に自己ループ (`from == to`) を無視するようにしました。
- **引数チェックの強化:** 頂点IDが負の場合に `ArgumentOutOfRangeException` をスローするように検証を追加・統一しました。
- **コンストラクタ・`AddEdges` の改善:** `ArgumentNullException.ThrowIfNull` の利用や例外メッセージの改善を行いました。
- **`GenerateReversed` の改善:** グラフを逆転させる際に、孤立した頂点も正しくコピーするように修正しました。
- **Dijkstra法の改善:** 潜在的なオーバーフローに関するコメントを追加し、コードを整理しました。
- **閉路検出・トポロジカルソート:** 内部で `GetVertices`, `GetNeighbors` を使用するように更新しました。

#### 3. `SimpleUndirectedGraph` の改善

- **デフォルト重みの変更:** `AddEdge(vertexA, vertexB)` やコンストラクタで辺を追加する際のデフォルト重みを `0L` から `1L` に変更し、`SimpleDirectedGraph` との整合性を図りました。
- **`EdgeCount` プロパティ実装の変更:** 辺の数を正確に追跡するため、内部カウンター (`_edgeCount`) を導入し、辺の追加・削除時に更新する方式に変更しました。
- **辺追加メソッドの改善:**
    - `AddEdge(vertexA, vertexB, weight)`: 辺が新規に追加された場合のみ辺カウント (`_edgeCount`) をインクリメントするように修正しました。
    - `AddOrUpdateEdge(vertexA, vertexB, weight)`: 辺が新規に追加された場合のみ辺カウント (`_edgeCount`) をインクリメントするロジックを追加しました。
- **自己ループの明示的な禁止:** 辺追加/更新時に自己ループ (`vertexA == vertexB`) を無視するようにしました。
- **頂点/辺削除処理の改善:** 頂点や辺を削除する際に、辺カウント (`_edgeCount`) が正しく更新されるように修正しました。
- **引数チェックの強化:** 頂点IDが負の場合に `ArgumentOutOfRangeException` をスローするように検証を追加・統一しました。
- **`GetEdgeWeight` の改善:** 頂点や辺が存在しない場合の例外メッセージをより具体的に改善しました。

#### 4. その他共通の改善

- **XMLドキュメントコメントの充実:** 各メソッドの機能、パラメータ、戻り値、スローされる例外について、より詳細かつ正確な情報を提供するようにコメントを全体的に見直し、更新しました。
- **.NET推奨プラクティスの適用:** `ArgumentNullException.ThrowIfNull` や `Array.Empty<T>` などの利用を推進しました。
- **Null許容参照型の適用:** `TryFindCycle` や `TryTopologicalSort` の `out` パラメータにNull許容注釈 (`?`) を追加しました。