### PR TITLE
Develop

### DIFF
--- a/TAmeAtCoderLibrary/SimpleUndirectedGraph.cs
+++ b/TAmeAtCoderLibrary/SimpleUndirectedGraph.cs
@@ -202,6 +202,7 @@ public class SimpleUndirectedGraph : SimpleDirectedGraph
         // 無向グラフの次数は、基底クラスの出次数と同じ (辺の追加/削除を両方向で行うため)。
         return base.GetOutDegree(vertex);
     }
+
     /// <summary>
     /// グラフ内の葉（次数0または1の頂点）であるすべての頂点を取得します。
     /// 孤立頂点（次数0）も葉と見なされます。

--- a/TAmeAtCoderLibrary/SimpleUndirectedGraph.cs
+++ b/TAmeAtCoderLibrary/SimpleUndirectedGraph.cs
@@ -204,6 +204,24 @@ public class SimpleUndirectedGraph : SimpleDirectedGraph
     }
 
     /// <summary>
+    /// このメソッドは無向グラフではサポートされていません。代わりに <see cref="GetDegree"/> を使用してください。
+    /// </summary>
+    [System.ObsoleteAttribute("Use GetDegree for undirected graphs. GetInDegree is not meaningful here.", true)]
+    public new int GetInDegree(int vertex)
+    {
+        throw new System.NotSupportedException("Use GetDegree for undirected graphs. GetInDegree is not meaningful for an undirected graph in this context.");
+    }
+
+    /// <summary>
+    /// このメソッドは無向グラフではサポートされていません。代わりに <see cref="GetDegree"/> を使用してください。
+    /// </summary>
+    [System.ObsoleteAttribute("Use GetDegree for undirected graphs. GetOutDegree is not meaningful here.", true)]
+    public new int GetOutDegree(int vertex)
+    {
+        throw new System.NotSupportedException("Use GetDegree for undirected graphs. GetOutDegree is not meaningful for an undirected graph in this context.");
+    }
+
+    /// <summary>
     /// グラフ内の葉（次数0または1の頂点）であるすべての頂点を取得します。
     /// 孤立頂点（次数0）も葉と見なされます。
     /// </summary>


### PR DESCRIPTION
このプルリクエストでは、**`SimpleUndirectedGraph`** クラスに特定の変更を加え、無向グラフにおける次数関連メソッドの正しい使用法を明確にし、適用します。具体的には、特定のメソッドを**廃止予定**とし、代替となるガイダンスを提供します。

### `SimpleUndirectedGraph`におけるメソッド使用法の強化：

* **`GetInDegree(int vertex)`** および **`GetOutDegree(int vertex)`** メソッド：これらのメソッドは、**`[System.Obsolete]`** と明示的にマークされ、無向グラフでは意味をなさないことを示すメッセージが追加されました。代わりに、ユーザーは **`GetDegree`** メソッドを使用するように指示されます。これらのメソッドが呼び出された場合、両方とも **`System.NotSupportedException`** をスローします。