### PR TITLE
feat: デカルト木の実装と順列・組合せ生成処理のリファクタリング

### DIFF
--- a/TAmeAtCoderLibrary/CartesianTree.cs
+++ b/TAmeAtCoderLibrary/CartesianTree.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace TAmeAtCoderLibrary;
 
 /// <summary>
@@ -26,17 +27,17 @@ public class CartesianTree<TKey, TValue> where TKey : IComparable<TKey> where TV
         /// <summary>
         /// ノードの親を取得または設定します。
         /// </summary>
-        public Node Parent { get; internal set; }
+        public Node? Parent { get; internal set; }
 
         /// <summary>
         /// ノードの左の子を取得または設定します。
         /// </summary>
-        public Node Left { get; internal set; }
+        public Node? Left { get; internal set; }
 
         /// <summary>
         /// ノードの右の子を取得または設定します。
         /// </summary>
-        public Node Right { get; internal set; }
+        public Node? Right { get; internal set; }
 
         /// <summary>
         /// <see cref="Node"/> クラスの新しいインスタンスを初期化します。
@@ -53,17 +54,18 @@ public class CartesianTree<TKey, TValue> where TKey : IComparable<TKey> where TV
     /// <summary>
     /// デカルトの木の根を取得します。
     /// </summary>
-    public Node Root { get; private set; }
+    public Node? Root { get; private set; }
 
     /// <summary>
     /// キーと値のペアのコレクションから木を構築することにより、<see cref="CartesianTree{TKey, TValue}"/> クラスの新しいインスタンスを初期化します。
-    /// 構築は、ソートのために O(n log n) で行われますが、入力がキーで事前にソートされている場合は O(n) です。
+    /// 構築は O(n log n) ですが、入力がキーでソート済みの場合は O(n) です。
     /// </summary>
     /// <param name="items">木を構築するためのキーと値のペアのコレクション。</param>
-    public CartesianTree(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    /// <param name="isAlreadySorted">入力シーケンスがキーで既にソートされているかどうかを示す値。</param>
+    public CartesianTree(IEnumerable<KeyValuePair<TKey, TValue>> items, bool isAlreadySorted = false)
     {
         // 木を効率的に構築するために、項目をキーでソートします。
-        var sortedItems = items.OrderBy(kvp => kvp.Key).ToArray();
+        var sortedItems = isAlreadySorted ? items.ToArray() : items.OrderBy(kvp => kvp.Key).ToArray();
         if (sortedItems.Length == 0)
         {
             return;

--- a/TAmeAtCoderLibrary/CartesianTree.cs
+++ b/TAmeAtCoderLibrary/CartesianTree.cs
@@ -1,0 +1,112 @@
+namespace TAmeAtCoderLibrary;
+
+/// <summary>
+/// デカルトの木を表します。
+/// （解説）https://gemini.google.com/share/fae3dcb949ad
+/// </summary>
+/// <typeparam name="TKey">キーの型。比較可能である必要があります。</typeparam>
+/// <typeparam name="TValue">値（優先度）の型。比較可能である必要があります。</typeparam>
+public class CartesianTree<TKey, TValue> where TKey : IComparable<TKey> where TValue : IComparable<TValue>
+{
+    /// <summary>
+    /// デカルトの木のノードを表します。
+    /// </summary>
+    public class Node
+    {
+        /// <summary>
+        /// ノードのキーを取得します。
+        /// </summary>
+        public TKey Key { get; }
+
+        /// <summary>
+        /// ノードの値（優先度）を取得します。
+        /// </summary>
+        public TValue Value { get; }
+
+        /// <summary>
+        /// ノードの親を取得または設定します。
+        /// </summary>
+        public Node Parent { get; internal set; }
+
+        /// <summary>
+        /// ノードの左の子を取得または設定します。
+        /// </summary>
+        public Node Left { get; internal set; }
+
+        /// <summary>
+        /// ノードの右の子を取得または設定します。
+        /// </summary>
+        public Node Right { get; internal set; }
+
+        /// <summary>
+        /// <see cref="Node"/> クラスの新しいインスタンスを初期化します。
+        /// </summary>
+        /// <param name="key">ノードのキー。</param>
+        /// <param name="value">ノードの値（優先度）。</param>
+        public Node(TKey key, TValue value)
+        {
+            Key = key;
+            Value = value;
+        }
+    }
+
+    /// <summary>
+    /// デカルトの木の根を取得します。
+    /// </summary>
+    public Node Root { get; private set; }
+
+    /// <summary>
+    /// キーと値のペアのコレクションから木を構築することにより、<see cref="CartesianTree{TKey, TValue}"/> クラスの新しいインスタンスを初期化します。
+    /// 構築は、ソートのために O(n log n) で行われますが、入力がキーで事前にソートされている場合は O(n) です。
+    /// </summary>
+    /// <param name="items">木を構築するためのキーと値のペアのコレクション。</param>
+    public CartesianTree(IEnumerable<KeyValuePair<TKey, TValue>> items)
+    {
+        // 木を効率的に構築するために、項目をキーでソートします。
+        var sortedItems = items.OrderBy(kvp => kvp.Key).ToArray();
+        if (sortedItems.Length == 0)
+        {
+            return;
+        }
+
+        // 最初の項目がルートになります。
+        Root = new Node(sortedItems[0].Key, sortedItems[0].Value);
+        Node lastNode = Root;
+
+        // 残りの項目を処理します。
+        for (int i = 1; i < sortedItems.Length; i++)
+        {
+            var (key, value) = (sortedItems[i].Key, sortedItems[i].Value);
+            var node = new Node(key, value);
+
+            // 新しいノードの正しい位置を見つけるために、木の右側の幹を上にたどります。
+            // 新しいノードの値よりも値（優先度）が小さいノードを探しています。
+            while (lastNode.Parent != null && lastNode.Value.CompareTo(value) > 0)
+            {
+                lastNode = lastNode.Parent;
+            }
+
+            // 新しいノードが現在の lastNode よりも高い優先度（小さい値）を持つ場合、
+            // それは、私たちがたどってきた部分木の新しいルートになります。
+            if (lastNode.Value.CompareTo(value) > 0)
+            {
+                node.Left = lastNode;
+                lastNode.Parent = node;
+                Root = node;
+            }
+            else
+            {
+                // それ以外の場合、新しいノードは lastNode の右の子になります。
+                // lastNode の以前の右の子は、新しいノードの左の子になります。
+                node.Left = lastNode.Right;
+                if (lastNode.Right != null)
+                {
+                    lastNode.Right.Parent = node;
+                }
+                lastNode.Right = node;
+                node.Parent = lastNode;
+            }
+            lastNode = node;
+        }
+    }
+}

--- a/TAmeAtCoderLibrary/Utilities/Common.cs
+++ b/TAmeAtCoderLibrary/Utilities/Common.cs
@@ -68,99 +68,87 @@ public static class Common
     }
     #endregion
 
-    #region Combinations and Permutations (Yield Return for Memory Efficiency)
+    #region Combinations and Permutations
 
     /// <summary>
-    /// 指定された範囲の数値から指定された個数を選択する組み合わせを列挙します (遅延評価)。
+    /// 指定された範囲の数値から指定された個数を選択する組み合わせを列挙します。
     /// </summary>
     /// <param name="n">選択対象の最大値 (1 から n)。</param>
     /// <param name="k">選択する個数。</param>
-    /// <returns>組み合わせのシーケンス。各組み合わせは int の IEnumerable。</returns>
+    /// <returns>組み合わせのリスト。各組み合わせは int の List。</returns>
     /// <exception cref="ArgumentOutOfRangeException">n, k が負、または k > n。</exception>
-    public static IEnumerable<IEnumerable<int>> GenerateCombinations(int n, int k)
+    public static List<List<int>> GenerateCombinations(int n, int k)
     {
         if (n < 0) throw new ArgumentOutOfRangeException(nameof(n), "n must be non-negative.");
         if (k < 0) throw new ArgumentOutOfRangeException(nameof(k), "k must be non-negative.");
         if (k > n) throw new ArgumentOutOfRangeException(nameof(k), "k cannot be greater than n.");
 
+        var allCombinations = new List<List<int>>();
         if (k == 0)
         {
-            yield return Enumerable.Empty<int>();
-            // yield break; // k=0 の場合は yield return の後に暗黙的に終了するので省略可
+            allCombinations.Add(new List<int>());
+            return allCombinations;
         }
-        else // k > 0 の場合
-        {
-            // CS1622 修正: GenerateCombinationsRecursive の結果を foreach で yield return する
-            foreach (var combination in GenerateCombinationsRecursive(1, n, k, 0, new int[k]))
-            {
-                yield return combination;
-            }
-        }
+
+        GenerateCombinationsRecursive(1, n, k, 0, new int[k], allCombinations);
+        return allCombinations;
     }
 
-    private static IEnumerable<IEnumerable<int>> GenerateCombinationsRecursive(int start, int n, int k, int index, int[] currentCombination)
+    private static void GenerateCombinationsRecursive(int start, int n, int k, int index, int[] currentCombination, List<List<int>> allCombinations)
     {
         if (index == k)
         {
-            yield return (int[])currentCombination.Clone();
+            allCombinations.Add(new List<int>(currentCombination));
+            return;
         }
-        else
+
+        for (int i = start; i <= n - (k - index - 1); i++)
         {
-            for (int i = start; i <= n - (k - index - 1); i++)
-            {
-                currentCombination[index] = i;
-                foreach (var combination in GenerateCombinationsRecursive(i + 1, n, k, index + 1, currentCombination))
-                    yield return combination;
-            }
+            currentCombination[index] = i;
+            GenerateCombinationsRecursive(i + 1, n, k, index + 1, currentCombination, allCombinations);
         }
     }
 
     /// <summary>
-    /// 指定された範囲の数値から指定された個数を選択する順列を列挙します (遅延評価)。
+    /// 指定された範囲の数値から指定された個数を選択する順列を列挙します。
     /// </summary>
     /// <param name="n">選択対象の最大値 (1 から n)。</param>
     /// <param name="k">選択する個数。</param>
-    /// <returns>順列のシーケンス。各順列は int の IEnumerable。</returns>
+    /// <returns>順列のリスト。各順列は int の List。</returns>
     /// <exception cref="ArgumentOutOfRangeException">n, k が負、または k > n。</exception>
-    public static IEnumerable<IEnumerable<int>> GeneratePermutations(int n, int k)
+    public static List<List<int>> GeneratePermutations(int n, int k)
     {
         if (n < 0) throw new ArgumentOutOfRangeException(nameof(n), "n must be non-negative.");
         if (k < 0) throw new ArgumentOutOfRangeException(nameof(k), "k must be non-negative.");
         if (k > n) throw new ArgumentOutOfRangeException(nameof(k), "k cannot be greater than n.");
 
+        var allPermutations = new List<List<int>>();
         if (k == 0)
         {
-            yield return Enumerable.Empty<int>();
-            // yield break; // k=0 の場合は yield return の後に暗黙的に終了するので省略可
+            allPermutations.Add(new List<int>());
+            return allPermutations;
         }
-        else // k > 0 の場合
-        {
-            // CS1622 修正: GeneratePermutationsRecursive の結果を foreach で yield return する
-            foreach (var permutation in GeneratePermutationsRecursive(n, k, 0, new int[k], new bool[n + 1]))
-            {
-                yield return permutation;
-            }
-        }
+
+        GeneratePermutationsRecursive(n, k, 0, new int[k], new bool[n + 1], allPermutations);
+        return allPermutations;
     }
 
-    private static IEnumerable<IEnumerable<int>> GeneratePermutationsRecursive(int n, int k, int index, int[] currentPermutation, bool[] used)
+    private static void GeneratePermutationsRecursive(int n, int k, int index, int[] currentPermutation, bool[] used, List<List<int>> allPermutations)
     {
         if (index == k)
         {
-            yield return (int[])currentPermutation.Clone();
+            allPermutations.Add(new List<int>(currentPermutation));
+            return;
         }
-        else
+
+        for (int i = 1; i <= n; i++)
         {
-            for (int i = 1; i <= n; i++)
+            if (!used[i])
             {
-                if (!used[i])
-                {
-                    used[i] = true;
-                    currentPermutation[index] = i;
-                    foreach (var permutation in GeneratePermutationsRecursive(n, k, index + 1, currentPermutation, used))
-                        yield return permutation;
-                    used[i] = false; // Backtrack
-                }
+                used[i] = true;
+                currentPermutation[index] = i;
+                GeneratePermutationsRecursive(n, k, index + 1, currentPermutation, used, allPermutations);
+                used[i] = false; // Backtrack
             }
         }
     }


### PR DESCRIPTION

## 概要 📝
このPull Requestでは、データ構造ライブラリに新しく**デカルト木（Cartesian Tree）**を追加します。
また、ユーティリティクラスの**組合せ・順列生成メソッドをリファクタリング**し、遅延評価 (`yield return`) からリストを返す実装に変更しました。

---

## 変更内容 🚀

### 新機能 ✨
-   **デカルト木 (`CartesianTree.cs`) の追加**
    -   キーに対しては**二分探索木**の性質を、値（優先度）に対しては**ヒープ**の性質を持つデータ構造を実装しました。
    -   `IEnumerable<KeyValuePair<TKey, TValue>>` から O(n log n) （キーでソート済みなら O(n)）で構築できます。

### リファクタリング ♻️
-   **組合せ・順列生成メソッドの変更 (`Common.cs`)**
    -   `GenerateCombinations` と `GeneratePermutations` の戻り値を `IEnumerable<IEnumerable<int>>` から `List<List<int>>` に変更しました。
    -   これにより、結果を即座にリストとして扱えるようになります。

---

## 変更の背景 🧐
-   **デカルト木**: データ構造のバリエーションを増やし、より広範な問題に対応できるようにするため。特にRMQ（Range Minimum Query）などのアルゴリズムの基礎となります。
-   **組合せ・順列生成**: 従来の遅延評価実装はメモリ効率が良い一方で、多くの利用シーンで結局 `ToList()` を呼び出す必要がありました。利用側のコードを簡潔にするため、予めリストを生成して返す設計へと見直しました。

---

## ⚠️ 破壊的変更 (BREAKING CHANGE)
`GenerateCombinations` および `GeneratePermutations` メソッドのシグネチャが変更されています。
-   **変更前**: `public static IEnumerable<IEnumerable<int>> GenerateCombinations(int n, int k)`
-   **変更後**: `public static List<List<int>> GenerateCombinations(int n, int k)`

この変更は既存のコードに影響を与える可能性があるため、マージの際はご注意ください。

---

## 関連するIssue 🔖
-   なし